### PR TITLE
修复配置目录创建失败导致的程序无法启动

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -10,7 +10,7 @@ from qfluentwidgets import (qconfig, QConfig, ConfigItem, Theme, OptionsConfigIt
 from app.utils.config_directory import get_ddnet_directory
 
 base_path = os.path.dirname(__file__)
-config_path = platformdirs.user_config_dir("DDNetToolBox")
+config_path = platformdirs.user_config_dir(appname="DDNetToolBox", appauthor="XCWQW233")
 
 
 class Language(Enum):

--- a/main.py
+++ b/main.py
@@ -11,8 +11,7 @@ from app.view.main_interface import MainWindow
 if __name__ == '__main__':
     # 初始化目录
     if not os.path.exists(f"{config_path}"):
-        os.mkdir(f"{config_path}")
-        os.mkdir(f"{config_path}/app")
+        os.makedirs(f"{config_path}/app", exist_ok=True)
 
     # 启用DPI
     if cfg.get(cfg.dpiScale) == "Auto":


### PR DESCRIPTION
修复配置目录创建失败导致的程序无法启动